### PR TITLE
Translate superscripts to parenthesized numbers.

### DIFF
--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -586,3 +586,14 @@ def test_powers(power, expected):
 def test_unicode(string, unit):
     assert u_format.Generic.parse(string) == unit
     assert u.Unit(string) == unit
+
+
+@pytest.mark.parametrize('string', [
+    'g\N{MICRO SIGN}',
+    'g\N{MINUS SIGN}',
+    'm\N{SUPERSCRIPT MINUS}1',
+    'm+\N{SUPERSCRIPT ONE}',
+    'm\N{MINUS SIGN}\N{SUPERSCRIPT ONE}'])
+def test_unicode_failures(string):
+    with pytest.raises(ValueError):
+        u.Unit(string)


### PR DESCRIPTION
This ensures that mixes of superscripts and normal characters fail.

I tried also my own suggestion of actually adding superscripts to the lexer/parser, but it failed (not quite clear why). And this is simpler, just sticking to translations.